### PR TITLE
add .description field to massmodel class

### DIFF
--- a/mass/core/massmodel.py
+++ b/mass/core/massmodel.py
@@ -68,6 +68,8 @@ class MassModel(Object):
 
     Attributes
     ----------
+    description: str
+        A human-readable description of the model.
     reactions: cobra.DictList
         A cobra.DictList where keys are the reaction identifiers and the
         values are the associated MassReaction objects.
@@ -133,6 +135,7 @@ class MassModel(Object):
             self.update_S(matrix_type=matrix_type, dtype=dtype)
         else:
             Object.__init__(self, id_or_model, name=name)
+            self.description = ''
             # Initialize DictLists for reactions, metabolites, and genes
             self.reactions = DictList()
             self.metabolites = DictList()


### PR DESCRIPTION
There needs to be a `model.description` field that contains a human-readable string of metadata associated with the model. This string would describe (ideally) what system the model represents, what type of model it is, what sort of content is represented, etc.